### PR TITLE
rockspec: use git+https:// for git repository URL

### DIFF
--- a/template-scm-1.rockspec
+++ b/template-scm-1.rockspec
@@ -1,7 +1,7 @@
 package = "template"
 version = "scm-1"
 source = {
-    url = "git://github.com/tarantool/template.git"
+    url = "git+https://github.com/tarantool/template.git"
 }
 description = {
     summary = "Templating Engine (HTML) for Tarantool",


### PR DESCRIPTION
GitHub is going to disable unencrypted Git protocol, so `git://` URLs
will stop working soon (see [1]).

[1]: https://github.blog/2021-09-01-improving-git-protocol-security-github/

Part of https://github.com/tarantool/tarantool/issues/6587